### PR TITLE
feat: Improvement of CompletionItemProvider

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,16 +1,17 @@
-import { TextDocument, languages, Position, CancellationToken, CompletionContext, CompletionItem, CompletionItemProvider, CompletionItemKind, ExtensionContext } from 'vscode'
+import { TextDocument, languages, Position, CompletionItem, CompletionItemProvider, CompletionItemKind, ExtensionContext, Range } from 'vscode'
 import { collections } from './collections'
 import { getIconMarkdown } from './markdown'
 import { config, REGEX_NAMESPACE } from './config'
 
 export function RegisterCompletion(ctx: ExtensionContext) {
   const provider: CompletionItemProvider = {
-    provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext) {
-      const match = document.getWordRangeAtPosition(position, REGEX_NAMESPACE.value)
+    provideCompletionItems(document: TextDocument, position: Position) {
+      const line = document.getText(new Range(new Position(position.line, 0), new Position(position.line, position.character)))
+      const match = line.match(REGEX_NAMESPACE.value)
       if (!match)
         return null
 
-      const id = document.getText(match).slice(1, -1)
+      const id = match[1]
       const info = collections.find(i => i.id === id)
       if (!info)
         return null

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,7 @@ export const color = computed(() => {
 })
 
 export const REGEX_NAMESPACE = computed(() => {
-  return new RegExp(`[^\\w\\d](?:${enabledCollections.value.join('|')})[${config.delimiters.join('')}]`)
+  return new RegExp(`[^\\w\\d](${enabledCollections.value.join('|')})[${config.delimiters.join('')}][\\w-]*$`)
 })
 
 export const REGEX_FULL = computed(() => {


### PR DESCRIPTION
I tried to show completion suggestions for input other than delimiter.

**before**

[![Image from Gyazo](https://i.gyazo.com/d6031415d06d56df69cc8ecbe45d8961.gif)](https://gyazo.com/d6031415d06d56df69cc8ecbe45d8961)

**after**

[![Image from Gyazo](https://i.gyazo.com/e8a4a24dd68f178afda17f7a8f296918.gif)](https://gyazo.com/e8a4a24dd68f178afda17f7a8f296918)