### PR TITLE
feat: change icon color based on activeColorTheme.kind

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { workspace } from 'vscode'
+import { ColorThemeKind, window, workspace } from 'vscode'
 import { reactive, computed, ref } from '@vue/reactivity'
 import { EXT_NAMESPACE } from './meta'
 import { collectionIds } from './collections'
@@ -94,7 +94,12 @@ export function onConfigUpdated() {
   _configState.value = +new Date()
 }
 
-export function isDarkTheme() {
+// First try the activeColorThemeKind (if available) otherwise apply regex on the color theme's name
+function isDarkTheme() {
+  const themeKind = window?.activeColorTheme?.kind
+  if (themeKind && themeKind === ColorThemeKind?.Dark)
+    return true
+
   const theme = createConfigRef('workbench.colorTheme', '', true)
 
   // must be dark


### PR DESCRIPTION
:bulb: 

## Issue
When using a theme that doesn't contain `dark | black | light` in its name, the `auto` color detection was failing. _(for example: 'Noctis Lux')_

## Solution
Use the `window.activeColorTheme.kind` provided by `vscode` ~instead~ in priority of the regex matching on the theme's name.

| Before |
|-|
| ![before](https://user-images.githubusercontent.com/1302282/156162685-a05fed99-9262-4e36-bb1d-0b753b652197.gif) |
| Can't see the icon on this light theme |

| After |
|-|
| ![after](https://user-images.githubusercontent.com/1302282/156162710-694776fa-81ea-4a6d-8970-fce304952f4d.gif) |
| All good |

Related to #6 