### PR TITLE
fix: readme img urls, new rating badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
 <a href="https://iconify.design">
-<img src="https://github.com/antfu/vscode-iconify/blob/master/screenshots/preface.png?raw=true" alt="logo" width='650'/>
+<img src="./screenshots/preface.png" alt="logo" width='650'/>
 </a>
 </p>
 
@@ -8,7 +8,8 @@
 <a href="https://marketplace.visualstudio.com/items?itemName=antfu.iconify" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/v/antfu.iconify.svg?color=blue&amp;label=VS%20Code%20Marketplace&logo=visual-studio-code" alt="Visual Studio Marketplace Version" /></a>
 <a href="https://marketplace.visualstudio.com/items?itemName=antfu.iconify" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/d/antfu.iconify.svg?color=4bdbe3" alt="Visual Studio Marketplace Downloads" /></a>
 <a href="https://marketplace.visualstudio.com/items?itemName=antfu.iconify" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/i/antfu.iconify.svg?color=63ba83" alt="Visual Studio Marketplace Installs" /></a>
-<a href="https://marketplace.visualstudio.com/items?itemName=antfu.iconify" target="__blank"><img src="https://vsmarketplacebadge.apphb.com/trending-monthly/antfu.iconify.svg?color=a1b858" alt="Marketplace Trending Monthly" /></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=antfu.iconify" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/r/antfu.iconify" alt="Visual Studio Marketplace Rating" /></a>
+
 <br/>
 <a href="https://github.com/antfu/vscode-iconify" target="__blank"><img src="https://img.shields.io/github/last-commit/antfu/vscode-iconify.svg?color=c977be" alt="GitHub last commit" /></a>
 <a href="https://github.com/antfu/vscode-iconify/issues" target="__blank"><img src="https://img.shields.io/github/issues/antfu/vscode-iconify.svg?color=a38eed" alt="GitHub issues" /></a>
@@ -18,7 +19,7 @@
 <br>
 
 <p align='center'>
-  <img src="https://github.com/antfu/vscode-iconify/blob/master/screenshots/preview-1.png?raw=true" alt='preview'>
+  <img src="./screenshots/preview-1.png" alt='preview'>
 </p>
 
 


### PR DESCRIPTION
- fixed the readme images, the url was the github link, not the actual image.
- deleted the "trending monthly badge because it was not working.
- added a new badge for vscode marketplace rating