### PR TITLE
update jsdelivr

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -2,4 +2,4 @@ export const EXT_NAMESPACE = 'iconify'
 export const EXT_ID = 'antfu.iconify'
 export const EXT_NAME = 'Iconify IntelliSense'
 
-export const COLLECTION_API = 'https://cdn.jsdelivr.net/gh/iconify/icon-sets/json'
+export const COLLECTION_API = 'https://fastly.jsdelivr.net/gh/iconify/icon-sets/json'


### PR DESCRIPTION
cdn.jsdelivr.net is banned in China.