### PR TITLE
chore: typo amodio.tls-problem-matcher

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "eamodio.tsl-problem-matcher"
+    "amodio.tsl-problem-matcher"
   ]
 }


### PR DESCRIPTION
`eamodio.tls-problem-matcher` should be `amodio.tls-problem-matcher`.

See publisher at https://github.com/eamodio/vscode-tsl-problem-matcher/blob/main/package.json#L10, unlike his name on Github




