### PR TITLE
fix(config): use github for cdnEntry

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export const config = reactive({
   excludes: createConfigRef<string[] | null>(`${EXT_NAMESPACE}.excludes`, null),
   fontSize: createConfigRef('editor.fontSize', 12),
   languageIds: createConfigRef(`${EXT_NAMESPACE}.languageIds`, []),
-  cdnEntry: createConfigRef(`${EXT_NAMESPACE}.cdnEntry`, 'https://cdn.jsdelivr.net/gh/iconify/icon-sets/json'),
+  cdnEntry: createConfigRef(`${EXT_NAMESPACE}.cdnEntry`, 'https://raw.githubusercontent.com/iconify/icon-sets/master/json'),
   customCollectionJsonPaths: createConfigRef(`${EXT_NAMESPACE}.customCollectionJsonPaths`, []),
 })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The current `config.cdnEntry` URL uses `cdn.jsdelivr.net/gh` to source iconify JSON data. I discovered that when using icons from a particularly large set, such as [noto](https://cdn.jsdelivr.net/gh/iconify/icon-sets/json/noto.json), there's apparently a 20MB size limit that was being exceeded. This was causing an annoying 403 error in my VSCode interface:

<img width="468" alt="Screen Shot 2022-09-18 at 3 44 47 PM" src="https://user-images.githubusercontent.com/11234104/190931347-e3c57612-4cb7-4224-af91-96f7f7cbdf66.png">

This PR replaces the JSDelivr URL with a direct link to `raw.githubusercontent.com` instead. 

### Linked Issues

Fixes issue #34.

### Additional context

Following a couple rudimentary speed tests between this and `unpkg.com`,  I concluded that using `raw.githubusercontent.com` for the CDN source was  the best way to go.

Thank you! 🫶🏼

<!-- e.g. is there anything you'd like reviewers to focus on? -->
