### PR TITLE
fix: remove regex global flag, close #53

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ const RE_PART_SUFFIXES = computed(() => {
 export const REGEX_DELIMITERS = computed(() => new RegExp(RE_PART_DELIMITERS.value, 'g'))
 
 export const REGEX_NAMESPACE = computed(() => {
-  return new RegExp(`[^\\w\\d]${RE_PART_PREFIXES.value}(${enabledCollectionIds.value.join('|')})${RE_PART_DELIMITERS.value}[\\w-]*$`, 'g')
+  return new RegExp(`[^\\w\\d]${RE_PART_PREFIXES.value}(${enabledCollectionIds.value.join('|')})${RE_PART_DELIMITERS.value}[\\w-]*$`)
 })
 
 export const REGEX_FULL = computed(() => {


### PR DESCRIPTION
### Description

Fixes #53. Intellisense breaks because of a bad global (`g`) flag on the regular expression used to extract components from the icon string, which ends up accidentally inserting the delimiter (e.g. `:`) into the icon collection name, causing the collection lookup to fail.

### Linked Issues

https://github.com/antfu/vscode-iconify/issues/53

### Additional context