### PR TITLE
feat: alias for icon collection name

### DIFF
--- a/package.json
+++ b/package.json
@@ -503,6 +503,11 @@
           },
           "default": [],
           "description": "JSON paths for custom collection"
+        },
+        "iconify.customCollectionIdsMap": {
+          "type": "object",
+          "default": {},
+          "description": "Collection IDs Map for collection name alias, e.g. { 'mc': 'mingcute' }"
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,7 @@ export const config = reactive({
   suffixes: createConfigRef(`${EXT_NAMESPACE}.suffixes`, ['']),
   cdnEntry: createConfigRef(`${EXT_NAMESPACE}.cdnEntry`, 'https://icones.js.org/collections'),
   customCollectionJsonPaths: createConfigRef(`${EXT_NAMESPACE}.customCollectionJsonPaths`, []),
+  customCollectionIdsMap: createConfigRef(`${EXT_NAMESPACE}.customCollectionIdsMap`, {} as Record<string, string | undefined>),
 })
 
 export const customCollections = ref([] as IconifyJSON[])
@@ -102,7 +103,11 @@ export const enabledCollectionIds = computed(() => {
   const includes = config.includes?.length ? config.includes : collectionIds
   const excludes = config.excludes || []
 
-  return [...includes.filter(i => !excludes.includes(i)), ...customCollections.value.map(c => c.prefix)]
+  return [
+    ...includes.filter(i => !excludes.includes(i)),
+    ...(Object.keys(config.customCollectionIdsMap)),
+    ...customCollections.value.map(c => c.prefix),
+  ]
 })
 
 export const enabledCollections = computed<IconsetMeta[]>(() => {
@@ -161,7 +166,7 @@ export function parseIcon(str: string) {
   if (!icon)
     return
 
-  return { collection, icon }
+  return { collection: config.customCollectionIdsMap[collection] ?? collection, icon }
 }
 
 export const color = computed(() => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[`@egoist/tailwindcss-icons`](https://github.com/egoist/tailwindcss-icons) has a [PR](https://github.com/egoist/tailwindcss-icons/pull/35) that allows custom icon collection names, which allows us to write `i-mc-tag-line` instead of the longer `i-mingcute-tag-line`, but this way we cannot have the icon display of this plugin at the same time.

After this PR, we can add the following configuration:

```json
{
  "iconify.customCollectionIdsMap": {
    "mc": "mingcute"
  }
}
```

![ScreenShot 2023-12-13 16 54 03](https://github.com/antfu/vscode-iconify/assets/38493346/6f49184b-5708-4657-87ee-1a6152c23f46)

Looking forward to your opinion.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
