### PR TITLE
feat: add color checking for HighContrastDark

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -185,8 +185,11 @@ export async function onConfigUpdated() {
 // First try the activeColorThemeKind (if available) otherwise apply regex on the color theme's name
 function isDarkTheme() {
   const themeKind = window?.activeColorTheme?.kind
-  if (themeKind && themeKind === ColorThemeKind?.Dark)
+  if (themeKind && (themeKind === ColorThemeKind?.Dark || themeKind === ColorThemeKind?.HighContrastDark))
     return true
+
+  if (themeKind && (themeKind === ColorThemeKind?.Light || themeKind === ColorThemeKind?.HighContrastLight))
+    return false
 
   const theme = createConfigRef('workbench.colorTheme', '', true)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR add enhancements to the theme recognition logic of Visual Studio Code.

It addresses the limitation in identifying the current `activeColorTheme.kind` when theme names _do not_ explicitly include `"light"` (e.g., `"Catppuccin Latte"`).

The proposed improvements expand the handling of `window.activeColorTheme.kind` to include `HighContrastDark`, `Light`, and `HighContrastLight` themes. Currently, the logic is restricted to the `Dark` type and relies on a regex fallback that necessitates the presence of `"light"` or `"dark"` in the theme name. 

### Linked Issues

n.a.


### Additional context

n.a.
