### PR TITLE
feat: Support Django HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "onLanguage:handlebars",
     "onLanguage:svelte",
     "onLanguage:html",
+    "onLanguage:django-html",
     "onLanguage:css"
   ],
   "contributes": {


### PR DESCRIPTION
### Description

`django-html` is a filetype added by the batisteo.vscode-django extension (fairly popular at 9.7 million downloads). When opening a file with a `templates/*.html` path, I noticed that the expected behavior didn't seem to occur.

### Linked Issues

N/A

### Additional context

Apologies if this PR is insufficient. I created it with very little knowledge of authoring VS Code extensions.