### PR TITLE
fix: icon too small for some icon sets

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -126,10 +126,10 @@ export async function getIconInfo(ctx: ExtensionContext, key: string) {
     return null
 
   if (!icon.width)
-    icon.width = data.width || 32
+    icon.width = data.width || 16
 
   if (!icon.height)
-    icon.height = data.height || 32
+    icon.height = data.height || 16
 
   icon.collection = result.collection
   icon.id = result.icon


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Iconify uses 16px as default size, but we're using 32px by default, this causes some icon sets without `width` and `height` fields set to be very small (e.g. Codicon, Bootstrap Icons)

> https://github.com/iconify/iconify/blob/c2b52cbf821c6d547f24cc0cc3b2d7a85d8e1bf1/packages/utils/src/icon/defaults.ts#L23-L30

Before:

![image](https://github.com/antfu/vscode-iconify/assets/68118705/c039e0a9-e7fa-4b3a-abda-6f5523cbf233)

After:

![image](https://github.com/antfu/vscode-iconify/assets/68118705/ff4fe9d2-0d80-403f-abd3-faa9f361116d)

### Linked Issues

Fixes #61

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

-