### PR TITLE
feat: Reload `customCollections` when `iconifyJSON` updated.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { computed, defineConfigObject, ref, shallowReactive, useFsWatcher, useIs
 import { Uri } from 'vscode'
 import { collectionIds, collections } from './collections'
 import * as Meta from './generated/meta'
+import { deleteTask } from './loader'
 import { Log } from './utils'
 
 export const config = defineConfigObject<Meta.ScopedConfigKeyTypeMap>(
@@ -58,7 +59,9 @@ export async function useCustomCollections() {
   async function load(url: URL) {
     Log.info(`Loading custom collections from:\n${url}`)
     try {
-      result.set(url.href, await fs.readJSON(url))
+      const val: IconifyJSON = await fs.readJSON(url)
+      result.set(url.href, val)
+      deleteTask(val.prefix)
     }
     catch {
       Log.error(`Error on loading custom collection: ${url}`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,8 @@ import type { IconifyJSON } from '@iconify/types'
 import type { IconsetMeta } from './collections'
 import { isAbsolute, resolve } from 'node:path'
 import fs from 'fs-extra'
-import { computed, defineConfigObject, ref, useIsDarkTheme, useWorkspaceFolders, watchEffect } from 'reactive-vscode'
+import { computed, defineConfigObject, ref, shallowReactive, useFsWatcher, useIsDarkTheme, useWorkspaceFolders, watchEffect } from 'reactive-vscode'
+import { Uri } from 'vscode'
 import { collectionIds, collections } from './collections'
 import * as Meta from './generated/meta'
 import { Log } from './utils'
@@ -28,8 +29,9 @@ export const customCollections = ref([] as IconifyJSON[])
 export async function useCustomCollections() {
   const workspaceFolders = useWorkspaceFolders()
 
-  watchEffect(async () => {
-    const result = [] as IconifyJSON[]
+  /** key is URL.href */
+  const result = shallowReactive(new Map<string, IconifyJSON>())
+  const iconifyJsonPaths = computed(() => {
     const files = Array.from(
       new Set(config.customCollectionJsonPaths.flatMap((file: string) => {
         if (isAbsolute(file))
@@ -44,28 +46,33 @@ export async function useCustomCollections() {
       })),
     )
 
-    const existingFiles = files.filter((file) => {
+    return files.filter((file) => {
       const exists = fs.existsSync(file)
       if (!exists)
         Log.warn(`Custom collection file does not exist: ${file}`)
       return exists
     })
-
-    if (existingFiles.length) {
-      Log.info(`Loading custom collections from:\n${existingFiles.map(i => `  - ${i}`).join('\n')}`)
-
-      await Promise.all(existingFiles.map(async (file) => {
-        try {
-          result.push(await fs.readJSON(file))
-        }
-        catch {
-          Log.error(`Error on loading custom collection: ${file}`)
-        }
-      }))
-    }
-
-    customCollections.value = result
   })
+  const { onDidChange, onDidDelete, onDidCreate } = useFsWatcher(iconifyJsonPaths)
+
+  async function load(url: URL) {
+    Log.info(`Loading custom collections from:\n${url}`)
+    try {
+      result.set(url.href, await fs.readJSON(url))
+    }
+    catch {
+      Log.error(`Error on loading custom collection: ${url}`)
+    }
+  }
+
+  // Initial load
+  iconifyJsonPaths.value.forEach(p => load(new URL(Uri.file(p))))
+
+  onDidChange(uri => load(new URL(uri)))
+  onDidCreate(uri => load(new URL(uri)))
+  onDidDelete(uri => result.delete(new URL(uri).href))
+
+  watchEffect(() => customCollections.value = Array.from(result.values()))
 }
 
 export const customAliases = ref([] as Record<string, string>[])

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -18,6 +18,9 @@ export function UniqPromise<T>(fn: (id: string) => Promise<T>) {
     return await _tasks[id]
   }
 }
+export function deleteTask(id: string) {
+  return delete _tasks[id]
+}
 
 function getCacheUri() {
   return Uri.joinPath(extensionContext.value!.globalStorageUri, 'icon-set-cache')


### PR DESCRIPTION
### Description

Before the PR, I have to restart vscode or use command `Developer: Reload Window` to make new icons work. After the PR, the configuration should takes effect immediately.

The changes only involve `useCustomCollections` function in `src/config.ts` and add `deleteTask` function to delete task in `_tasks` in `src/loader.ts`, and the only two side-effect is `customCollections` in `src/config.ts` and `_tasks` in `src/loader.ts`. It updates `customCollections` when needed, to achieve the feature.

### Linked Issues

Closes #89

### Additional context

The PR is not ready to be merged now. Here is a TODO list:

- [ ] The PR is actually dependent on `reactive-vscode@0.2.5`. I did not bump it because I think I'd better keep the PR clean.
- [x] It still not work perfectly. When I add a new icon, the completion worked well but there is no preview image. When I delete the icon, the completion was also removed. I have checked that `customCollections` was updated correctly so I think the issue's got to be somewhere else. I am still working on that.

There is one problem that has not been solved yet. `useFsWatcher` is based on `workspace.createFileSystemWatcher`, which cannot watch a file that not exists. Because `config.customCollectionJsonPaths` using a path instead of a glob, so I have no idea how to deal with the files created or deleted.