### PR TITLE
fix: match collections names with length first

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -136,6 +136,17 @@ export const enabledCollectionIds = computed(() => {
   ].sort((a, b) => b.length - a.length)
 })
 
+export const enabledCollections = computed<IconsetMeta[]>(() => {
+  const customData: IconsetMeta[] = customCollections.value.map(c => ({
+    id: c.prefix,
+    name: c.info?.name,
+    author: c.info?.author.name,
+    icons: Object.keys(c.icons),
+    height: c.info?.height,
+  }))
+  return [...collections, ...customData]
+})
+
 export const enabledAliases = computed((): Record<string, string> => {
   const flat: Record<string, string> = {}
   for (const aliases of customAliases.value) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,18 +133,7 @@ export const enabledCollectionIds = computed(() => {
     ...includes.filter(i => !excludes.includes(i)),
     ...(Object.keys(config.customCollectionIdsMap)),
     ...customCollections.value.map(c => c.prefix),
-  ].sort().reverse()
-})
-
-export const enabledCollections = computed<IconsetMeta[]>(() => {
-  const customData: IconsetMeta[] = customCollections.value.map(c => ({
-    id: c.prefix,
-    name: c.info?.name,
-    author: c.info?.author.name,
-    icons: Object.keys(c.icons),
-    height: c.info?.height,
-  }))
-  return [...collections, ...customData]
+  ].sort((a, b) => b.length - a.length)
 })
 
 export const enabledAliases = computed((): Record<string, string> => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,7 @@ export const enabledCollectionIds = computed(() => {
     ...includes.filter(i => !excludes.includes(i)),
     ...(Object.keys(config.customCollectionIdsMap)),
     ...customCollections.value.map(c => c.prefix),
-  ]
+  ].sort().reverse()
 })
 
 export const enabledCollections = computed<IconsetMeta[]>(() => {

--- a/test/fixture/index.html
+++ b/test/fixture/index.html
@@ -5,5 +5,6 @@
   <span icon='logos:vue'></span>
   <span icon='fa:500px'></span>
   <span icon='twemoji:adhesive-bandage'></span>
+  <span icon='material-symbols-light:123'></span>
   <span icon='custom:icon1'></span>
 </div>


### PR DESCRIPTION
### Description

match the wrong icon for string like 'material-symbols-light:123'

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
