### PR TITLE
chore: update `reactive-vscode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -645,7 +645,7 @@
     "esno": "^4.8.0",
     "fs-extra": "^11.2.0",
     "ofetch": "^1.4.1",
-    "reactive-vscode": "^0.2.7",
+    "reactive-vscode": "^0.2.8",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "vscode-ext-gen": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -645,7 +645,7 @@
     "esno": "^4.8.0",
     "fs-extra": "^11.2.0",
     "ofetch": "^1.4.1",
-    "reactive-vscode": "0.2.5",
+    "reactive-vscode": "^0.2.7",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "vscode-ext-gen": "^0.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       reactive-vscode:
-        specifier: ^0.2.7
-        version: 0.2.7(@types/vscode@1.95.0)
+        specifier: ^0.2.8
+        version: 0.2.8(@types/vscode@1.95.0)
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(jiti@1.21.6)(postcss@8.4.39)(tsx@4.19.1)(typescript@5.6.3)(yaml@2.4.5)
@@ -621,8 +621,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@reactive-vscode/reactivity@0.2.7':
-    resolution: {integrity: sha512-o8oHPo07zYx/oyvIeBBFvmrUFVYOWuXJz/0GfLFiX85FvCGKtfaAMxXrzlJ/zWsJyCM2uYGilnSmmePQNOFh9g==}
+  '@reactive-vscode/reactivity@0.2.8':
+    resolution: {integrity: sha512-AZYuPxUtFQ2Tygurj8y17yTsYQFuJX5JSbGQdRRVco4mdzKvN6EGoBL285BrjtINWDiX54ojBOiOCIcFKNB29A==}
 
   '@rollup/rollup-android-arm-eabi@4.27.2':
     resolution: {integrity: sha512-Tj+j7Pyzd15wAdSJswvs5CJzJNV+qqSUcr/aCD+jpQSBtXvGnV0pnrjoc8zFTe9fcKCatkpFpOO7yAzpO998HA==}
@@ -2449,8 +2449,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  reactive-vscode@0.2.7:
-    resolution: {integrity: sha512-iaNcSYBWG3muX/6LYAo3l9cVKIJ65VUyskDNAKSIB/u8VsO6j2RSN++kl83ovj5JI1xsfMwGyvZgQscMWE7jOg==}
+  reactive-vscode@0.2.8:
+    resolution: {integrity: sha512-x//CUHnWS7W6znrIdZ/NXimTmpvbX66GPmhX8TU89weLzd79uTYhbbpsAFLfTn+CPtUrmy7N1Wpx3faLd499Qg==}
     peerDependencies:
       '@types/vscode': ^1.89.0
 
@@ -3414,7 +3414,7 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@reactive-vscode/reactivity@0.2.7': {}
+  '@reactive-vscode/reactivity@0.2.8': {}
 
   '@rollup/rollup-android-arm-eabi@4.27.2':
     optional: true
@@ -5582,9 +5582,9 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  reactive-vscode@0.2.7(@types/vscode@1.95.0):
+  reactive-vscode@0.2.8(@types/vscode@1.95.0):
     dependencies:
-      '@reactive-vscode/reactivity': 0.2.7
+      '@reactive-vscode/reactivity': 0.2.8
       '@types/vscode': 1.95.0
 
   read-pkg-up@7.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       reactive-vscode:
-        specifier: 0.2.5
-        version: 0.2.5(@types/vscode@1.95.0)
+        specifier: ^0.2.7
+        version: 0.2.7(@types/vscode@1.95.0)
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(jiti@1.21.6)(postcss@8.4.39)(tsx@4.19.1)(typescript@5.6.3)(yaml@2.4.5)
@@ -621,8 +621,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@reactive-vscode/reactivity@0.2.5':
-    resolution: {integrity: sha512-Oq6V7gQ0WI7TKbBkY2xLE2aKqIZjs30sMcj+Bv2boqjwBWGQrnnOGOpDKMKtTUBDZnY7WdPgtiL9u92Kn+2qUw==}
+  '@reactive-vscode/reactivity@0.2.7':
+    resolution: {integrity: sha512-o8oHPo07zYx/oyvIeBBFvmrUFVYOWuXJz/0GfLFiX85FvCGKtfaAMxXrzlJ/zWsJyCM2uYGilnSmmePQNOFh9g==}
 
   '@rollup/rollup-android-arm-eabi@4.27.2':
     resolution: {integrity: sha512-Tj+j7Pyzd15wAdSJswvs5CJzJNV+qqSUcr/aCD+jpQSBtXvGnV0pnrjoc8zFTe9fcKCatkpFpOO7yAzpO998HA==}
@@ -2449,8 +2449,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  reactive-vscode@0.2.5:
-    resolution: {integrity: sha512-CknY2aedEzSfUhlOplIutBC6+xNvhrcz8rcS6UKTeyqHIfDz7pc6c/tlEboChqEeZvSXHhoo7FYoiYjR5pb2og==}
+  reactive-vscode@0.2.7:
+    resolution: {integrity: sha512-iaNcSYBWG3muX/6LYAo3l9cVKIJ65VUyskDNAKSIB/u8VsO6j2RSN++kl83ovj5JI1xsfMwGyvZgQscMWE7jOg==}
     peerDependencies:
       '@types/vscode': ^1.89.0
 
@@ -3414,7 +3414,7 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@reactive-vscode/reactivity@0.2.5': {}
+  '@reactive-vscode/reactivity@0.2.7': {}
 
   '@rollup/rollup-android-arm-eabi@4.27.2':
     optional: true
@@ -5582,9 +5582,9 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  reactive-vscode@0.2.5(@types/vscode@1.95.0):
+  reactive-vscode@0.2.7(@types/vscode@1.95.0):
     dependencies:
-      '@reactive-vscode/reactivity': 0.2.5
+      '@reactive-vscode/reactivity': 0.2.7
       '@types/vscode': 1.95.0
 
   read-pkg-up@7.0.1:

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -47,8 +47,8 @@ export function useAnnotations() {
     }
 
     const { document } = editor.value
-    const previewIncludePatterns = config['preview.include'] || []
-    const previewExcludePatterns = config['preview.exclude'] || []
+    const previewIncludePatterns = config.preview.include || []
+    const previewExcludePatterns = config.preview.exclude || []
 
     let shouldPreview = previewIncludePatterns.length
       ? previewIncludePatterns.some(pattern => !!languages.match({ pattern }, document))

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import * as Meta from './generated/meta'
 import { deleteTask } from './loader'
 import { Log } from './utils'
 
-export const config = defineConfigObject<Meta.ScopedConfigKeyTypeMap>(
+export const config = defineConfigObject<Meta.NestedScopedConfigs>(
   Meta.scopedConfigs.scope,
   Meta.scopedConfigs.defaults,
 )


### PR DESCRIPTION
A repro of `reactive-vscode` v0.2.7 that cause proxy errors in this project.

Check into this branch, install the deps and press `F5` to develop, the error would be shown as:

<img width="1354" alt="Screenshot 2024-11-17 at 23 18 18" src="https://github.com/user-attachments/assets/f8215a60-00f5-404d-ba5c-8b234efefede">
