### PR TITLE
feat: allow config files to be jsonc files

### DIFF
--- a/package.json
+++ b/package.json
@@ -646,6 +646,7 @@
     "fs-extra": "^11.2.0",
     "ofetch": "^1.4.1",
     "reactive-vscode": "^0.2.8",
+    "strip-json-comments": "^5.0.1",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
     "vscode-ext-gen": "^0.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       reactive-vscode:
         specifier: ^0.2.8
         version: 0.2.8(@types/vscode@1.95.0)
+      strip-json-comments:
+        specifier: ^5.0.1
+        version: 5.0.1
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(jiti@1.21.6)(postcss@8.4.39)(tsx@4.19.1)(typescript@5.6.3)(yaml@2.4.5)
@@ -2650,6 +2653,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.1:
+    resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
+    engines: {node: '>=14.16'}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -5798,6 +5805,8 @@ snapshots:
     optional: true
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.1: {}
 
   sucrase@3.35.0:
     dependencies:

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import { Uri } from 'vscode'
 import { collectionIds, collections } from './collections'
 import * as Meta from './generated/meta'
 import { deleteTask } from './loader'
-import { Log } from './utils'
+import { Log, readJSON } from './utils'
 
 export const config = defineConfigObject<Meta.NestedScopedConfigs>(
   Meta.scopedConfigs.scope,
@@ -61,7 +61,7 @@ export async function useCustomCollections() {
   async function load(url: URL) {
     Log.info(`Loading custom collections from:\n${url}`)
     try {
-      const val: IconifyJSON = await fs.readJSON(url)
+      const val: IconifyJSON = await readJSON(url)
       result.set(url.href, val)
       deleteTask(val.prefix)
     }
@@ -114,7 +114,7 @@ export async function useCustomAliases() {
 
       await Promise.all(existingFiles.map(async (file) => {
         try {
-          result.push(await fs.readJSON(file))
+          result.push(await readJSON(file))
         }
         catch {
           Log.error(`Error on loading custom aliases: ${file}`)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './Log'
+export * from './read-file'
 export * from './svgs'
 export * from './types'

--- a/src/utils/read-file.ts
+++ b/src/utils/read-file.ts
@@ -1,0 +1,14 @@
+import type { PathLike } from 'fs-extra'
+import fs from 'fs-extra'
+import stripJsonComments from 'strip-json-comments'
+
+/**
+ * Read and parse a JSON file.
+ *
+ * Note: The file can contain comments and trailing commas.
+ */
+export async function readJSON(filePath: PathLike) {
+  const contents = await fs.readFile(filePath, { encoding: 'utf8' })
+  const stripped = stripJsonComments(contents, { trailingCommas: true })
+  return JSON.parse(stripped)
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

User json files can now contain comments and trailing commas.

### Linked Issues

fix #98

