### PR TITLE
fix: adjust range startIndex in completion for prefix handling

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -14,7 +14,10 @@ export function useCompletion() {
       if (!prefixMatch)
         return null
 
-      const range = new Range(position.line, position.character, position.line, position.character)
+      // Index of the first character after the prefix
+      const startIndex = prefixMatch.index! + 1
+
+      const range = new Range(position.line, startIndex, position.line, position.character)
       const aliasCompletion = enabledAliasIds.value.map((i) => {
         const item = new CompletionItem(i, CompletionItemKind.Text)
         item.detail = `alias: ${i}`


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix an issue with the auto-completion not taking into account the content after the prefix. This was making the completion suggesting the whole icons of a library instead of looking first for completion of the icon's name.
Before : "lucide:plus" => ctrl + space => suggesting all icons
Now : "lucide:plus" => ctrl + space => "bell-**plus**", "book-**plus**"…

### Linked Issues
Fix #81 
